### PR TITLE
ci: environment variable for publication key

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,10 @@ jobs:
         with:
           tool: just@1
       - run: just verify
+      - run: ./gradlew publishPlugins -Pversion=0.0.0 --validate-only
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
 
   # Prepare a release PR or release
   release:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,8 +60,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: just@1
-      - name: Setup publication key
-        run: echo "${{ secrets.GRADLE_PUBLISH_CONFIG }}" > ~/.gradle/gradle.properties
       - run: just publish
-      - run: rm -f ~/.gradle/gradle.properties
-        if: ${{ always() }}
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@ set dotenv-load
 
 verify:
     ./gradlew check
+    ./gradlew publishPlugins -Pversion=0.0.0 --validate-only
     ./gradlew -p example check
 
 test:

--- a/justfile
+++ b/justfile
@@ -2,7 +2,6 @@ set dotenv-load
 
 verify:
     ./gradlew check
-    ./gradlew publishPlugins -Pversion=0.0.0 --validate-only
     ./gradlew -p example check
 
 test:


### PR DESCRIPTION
Looks like we can use environment variables for the publication key and secret.

I think that is a preferable option.

I also found that we can verify the plugin publication setup, so I added that step to the `verify` job.