### PR TITLE
feat: Add configuration for version fields

### DIFF
--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -45,7 +45,7 @@ public data class JooqDatabaseConfig(
     /** Name of the jOOQ database connector (e.g. 'org.jooq.meta.postgres.PostgresDatabase') */
     internal val name: String,
     internal val inputSchema: String,
-    internal val recordVersionFields: List<String>,
+    internal val recordVersionFields: List<String> = emptyList(),
 ) : Serializable {
     public companion object {
         public fun postgres(

--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -45,13 +45,16 @@ public data class JooqDatabaseConfig(
     /** Name of the jOOQ database connector (e.g. 'org.jooq.meta.postgres.PostgresDatabase') */
     internal val name: String,
     internal val inputSchema: String,
-    internal val recordVersionFields: String,
+    internal val recordVersionFields: List<String>,
 ) : Serializable {
-    internal companion object {
-        val postgres: JooqDatabaseConfig = JooqDatabaseConfig(
+    public companion object {
+        public fun postgres(
+            schema: String = "public",
+            recordVersionFields: List<String> = emptyList(),
+        ): JooqDatabaseConfig = JooqDatabaseConfig(
             name = "org.jooq.meta.postgres.PostgresDatabase",
-            inputSchema = "public",
-            recordVersionFields = "",
+            inputSchema = schema,
+            recordVersionFields = recordVersionFields,
         )
     }
 }

--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -45,11 +45,13 @@ public data class JooqDatabaseConfig(
     /** Name of the jOOQ database connector (e.g. 'org.jooq.meta.postgres.PostgresDatabase') */
     internal val name: String,
     internal val inputSchema: String,
+    internal val recordVersionFields: String,
 ) : Serializable {
     internal companion object {
         val postgres: JooqDatabaseConfig = JooqDatabaseConfig(
             name = "org.jooq.meta.postgres.PostgresDatabase",
             inputSchema = "public",
+            recordVersionFields = "",
         )
     }
 }

--- a/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
@@ -58,6 +58,7 @@ private fun JooqGeneratorConfig.toConfiguration(jdbcUrl: String) =
                     Database()
                         .withName(database.name)
                         .withInputSchema(database.inputSchema)
+                        .withRecordVersionFields(database.recordVersionFields)
                         .withExcludes("flyway_schema_history")
                 )
                 .withGenerate(

--- a/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
@@ -58,7 +58,7 @@ private fun JooqGeneratorConfig.toConfiguration(jdbcUrl: String) =
                     Database()
                         .withName(database.name)
                         .withInputSchema(database.inputSchema)
-                        .withRecordVersionFields(database.recordVersionFields)
+                        .withRecordVersionFields(database.recordVersionFields.joinToString("|"))
                         .withExcludes("flyway_schema_history")
                 )
                 .withGenerate(

--- a/src/main/kotlin/com/optravis/jooq/gradle/JooqGeneratorPlugin.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/JooqGeneratorPlugin.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalJooqGeneratorConfig::class)
-
 package com.optravis.jooq.gradle
 
 import org.gradle.api.DefaultTask
@@ -35,6 +33,7 @@ private object Default {
     const val PASSWORD = "jooq"
 }
 
+@OptIn(ExperimentalJooqGeneratorConfig::class)
 public class JooqGeneratorPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = with(project) {
         val extension = createExtension()
@@ -70,13 +69,14 @@ public class JooqGeneratorPlugin : Plugin<Project> {
         extensions.create<JooqGeneratorExtension>("jooqGeneratorExtension").apply {
             containerConfig.convention(ContainerConfig.postgres(Default.DB, Default.USER, Default.PASSWORD))
             connectionConfig.convention(DbConnectionConfig.postgres(Default.DB, Default.USER, Default.PASSWORD))
-            jooqDbConfig.convention(JooqDatabaseConfig.postgres)
+            jooqDbConfig.convention(JooqDatabaseConfig.postgres())
             migrationDirectory.convention(File("${project.layout.projectDirectory}/src/main/resources/db/migration"))
             deprecateUnknownTypes.convention(true)
             javaTimeTypes.convention(true)
         }
 }
 
+@OptIn(ExperimentalJooqGeneratorConfig::class)
 private abstract class JooqGenerateTask : DefaultTask() {
 
     @get:Input


### PR DESCRIPTION
Adds ad jooqDatabaseConfig property `recordVersionFields` (defaulting to "") that allows a user to set the fields that make up a version. This is used for Optimistic locking implementations.

see https://www.jooq.org/doc/latest/manual/code-generation/codegen-advanced/codegen-config-database/codegen-database-record-version-timestamp-fields/