### PR TITLE
feat!: Extend Generator Configuration to capture Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ jooqGenerator {
   generatorConfig.set(
     JooqGeneratorConfig(
       deprecateUnknownTypes = true,
-      kotlinPojos = true,
+      daos = true,
+      pojos = true,
       javaTimeTypes = true,
     )
   )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 
     testImplementation(rootProject.libs.kotest.runner)
     testImplementation(rootProject.libs.kotest.assertions)
+    testImplementation(rootProject.libs.kotest.datatest)
 }
 
 gradlePlugin {

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -21,7 +21,8 @@ jooqGenerator {
     generatorConfig.set(
         JooqGeneratorConfig(
             deprecateUnknownTypes = true,
-            kotlinPojos = true,
+            daos = true,
+            pojos = true,
             javaTimeTypes = true,
         )
     )

--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -32,6 +32,7 @@ public data class JooqGeneratorConfig(
     internal val deprecateUnknownTypes: Boolean = true,
     internal val javaTimeTypes: Boolean = true,
     internal val pojos: Boolean = true,
+    internal val daos: Boolean = true,
 ) : Serializable
 
 public enum class GeneratorType {

--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -31,7 +31,7 @@ public data class JooqGeneratorConfig(
     internal val generatorType: GeneratorType = GeneratorType.Kotlin,
     internal val deprecateUnknownTypes: Boolean = true,
     internal val javaTimeTypes: Boolean = true,
-    internal val kotlinPojos: Boolean = true,
+    internal val pojos: Boolean = true,
 ) : Serializable
 
 public enum class GeneratorType {

--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -28,10 +28,21 @@ internal data class JooqRootConfig(
 
 @ExperimentalJooqGeneratorConfig
 public data class JooqGeneratorConfig(
+    internal val generatorType: GeneratorType = GeneratorType.Kotlin,
     internal val deprecateUnknownTypes: Boolean = true,
     internal val javaTimeTypes: Boolean = true,
     internal val kotlinPojos: Boolean = true,
 ) : Serializable
+
+public enum class GeneratorType {
+    Java,
+    Kotlin,
+    Scala,
+    XML,
+    ;
+
+    internal val fullyQualifiedName: String get() = "org.jooq.codegen.${name}Generator"
+}
 
 @ExperimentalJooqGeneratorConfig
 public data class ContainerConfig(

--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -38,6 +38,7 @@ public data class JooqGeneratorConfig(
 ) : Serializable
 
 /** Generator type currently supported by this plugin. */
+@ExperimentalJooqGeneratorConfig
 public enum class GeneratorType {
     Java,
     Kotlin,

--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -37,11 +37,10 @@ public data class JooqGeneratorConfig(
     internal val daos: Boolean = true,
 ) : Serializable
 
+/** Generator type currently supported by this plugin. */
 public enum class GeneratorType {
     Java,
     Kotlin,
-    Scala,
-    XML,
     ;
 
     internal val fullyQualifiedName: String get() = "org.jooq.codegen.${name}Generator"

--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -31,7 +31,9 @@ public data class JooqGeneratorConfig(
     internal val generatorType: GeneratorType = GeneratorType.Kotlin,
     internal val deprecateUnknownTypes: Boolean = true,
     internal val javaTimeTypes: Boolean = true,
-    internal val pojos: Boolean = true,
+    @Deprecated("Use pojos instead", ReplaceWith("pojos"))
+    internal val kotlinPojos: Boolean = true,
+    internal val pojos: Boolean = kotlinPojos,
     internal val daos: Boolean = true,
 ) : Serializable
 

--- a/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
@@ -61,7 +61,7 @@ private fun JooqRootConfig.toConfiguration(jdbcUrl: String) =
                         .withRecordVersionFields(database.recordVersionFields.joinToString("|"))
                         .withExcludes("flyway_schema_history")
                 )
-                .withGenerate(generateSpecifically())
+                .withGenerate(generator.toJooqGenerate())
                 .withTarget(
                     Target()
                         .withPackageName(target.packageName)
@@ -69,13 +69,13 @@ private fun JooqRootConfig.toConfiguration(jdbcUrl: String) =
                 )
         )
 
-private fun JooqRootConfig.generateSpecifically(): Generate {
+private fun JooqGeneratorConfig.toJooqGenerate(): Generate {
     val common = Generate()
-        .withDaos(generator.daos)
-        .withPojos(generator.pojos)
-        .withJavaTimeTypes(generator.javaTimeTypes)
-        .withDeprecationOnUnknownTypes(generator.deprecateUnknownTypes)
-    return when (generator.generatorType) {
+        .withDaos(daos)
+        .withPojos(pojos)
+        .withJavaTimeTypes(javaTimeTypes)
+        .withDeprecationOnUnknownTypes(deprecateUnknownTypes)
+    return when (generatorType) {
         GeneratorType.Kotlin -> common
             .withPojosAsKotlinDataClasses(true)
             .withKotlinDefaultedNullablePojoAttributes(true)
@@ -84,7 +84,7 @@ private fun JooqRootConfig.generateSpecifically(): Generate {
             .withKotlinNotNullInterfaceAttributes(true)
             .withKotlinNotNullRecordAttributes(true)
 
-        else -> common
+        GeneratorType.Java -> common
     }
 }
 

--- a/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
@@ -53,7 +53,7 @@ private fun JooqRootConfig.toConfiguration(jdbcUrl: String) =
         )
         .withGenerator(
             Generator()
-                .withName("org.jooq.codegen.KotlinGenerator")
+                .withName(generator.generatorType.fullyQualifiedName)
                 .withDatabase(
                     Database()
                         .withName(database.name)

--- a/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
@@ -71,7 +71,7 @@ private fun JooqRootConfig.toConfiguration(jdbcUrl: String) =
 
 private fun JooqRootConfig.generateSpecifically(): Generate {
     val common = Generate()
-        .withDaos(true)
+        .withDaos(generator.daos)
         .withPojos(generator.pojos)
         .withJavaTimeTypes(generator.javaTimeTypes)
         .withDeprecationOnUnknownTypes(generator.deprecateUnknownTypes)

--- a/src/test/kotlin/com/optravis/jooq/gradle/GeneratorTypeSpec.kt
+++ b/src/test/kotlin/com/optravis/jooq/gradle/GeneratorTypeSpec.kt
@@ -1,0 +1,13 @@
+package com.optravis.jooq.gradle
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+
+class GeneratorTypeSpec : FunSpec({
+    context("each `fullyQualifiedName` class should be in classpath") {
+        withData(GeneratorType.entries) { type ->
+            shouldNotThrow<ClassNotFoundException> { Class.forName(type.fullyQualifiedName) }
+        }
+    }
+})


### PR DESCRIPTION
- Allows to switch generator type (Java, Kotlin, Scala, XML), defaulting to KotlinGenerator
- Refurbish `JooqGeneratorConfig.kotlinPojos` to `JooqGeneratorConfig.pojos`, specfiying if we want pojos or not. Depending on the GeneratorType, we do set the kotlin specific attributes or not. Defaults to `true`. Keeps the deprecated `kotlinPojos` to be removed later.
- Make dao generation configurable (defaulting to `true`)
