### PR TITLE
feat: make `GeneratorType` non-exhaustive

### DIFF
--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -39,12 +39,14 @@ public data class JooqGeneratorConfig(
 
 /** Generator type currently supported by this plugin. */
 @ExperimentalJooqGeneratorConfig
-public enum class GeneratorType {
-    Java,
-    Kotlin,
-    ;
-
-    internal val fullyQualifiedName: String get() = "org.jooq.codegen.${name}Generator"
+public class GeneratorType private constructor(
+    internal val fullyQualifiedName: String,
+) : Serializable {
+    public companion object {
+        public val Java: GeneratorType = create(lang = "Java")
+        public val Kotlin: GeneratorType = create(lang = "Kotlin")
+        private fun create(lang: String) = GeneratorType("org.jooq.codegen.${lang}Generator")
+    }
 }
 
 @ExperimentalJooqGeneratorConfig

--- a/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
@@ -85,6 +85,7 @@ private fun JooqGeneratorConfig.toJooqGenerate(): Generate {
             .withKotlinNotNullRecordAttributes(true)
 
         GeneratorType.Java -> common
+        else -> error("unsupported generator: $generatorType. This is a bug, please report it to https://github.com/Optravis-LLC/jooq-gradle/issues")
     }
 }
 

--- a/src/test/kotlin/com/optravis/jooq/gradle/GeneratorTypeSpec.kt
+++ b/src/test/kotlin/com/optravis/jooq/gradle/GeneratorTypeSpec.kt
@@ -15,9 +15,11 @@ class GeneratorTypeSpec : FunSpec({
     }
     test("should equal self") {
         GeneratorType.Kotlin shouldBeEqual GeneratorType.Kotlin
+        GeneratorType.Kotlin.fullyQualifiedName shouldBeEqual GeneratorType.Kotlin.fullyQualifiedName
         GeneratorType.Kotlin.hashCode() shouldBeEqual GeneratorType.Kotlin.hashCode()
     }
     test("should not equal other") {
         GeneratorType.Kotlin shouldNotBeEqual GeneratorType.Java
+        GeneratorType.Kotlin.fullyQualifiedName shouldNotBeEqual GeneratorType.Java.fullyQualifiedName
     }
 })

--- a/src/test/kotlin/com/optravis/jooq/gradle/GeneratorTypeSpec.kt
+++ b/src/test/kotlin/com/optravis/jooq/gradle/GeneratorTypeSpec.kt
@@ -3,11 +3,21 @@ package com.optravis.jooq.gradle
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.equals.shouldNotBeEqual
 
+@OptIn(ExperimentalJooqGeneratorConfig::class)
 class GeneratorTypeSpec : FunSpec({
     context("each `fullyQualifiedName` class should be in classpath") {
-        withData(GeneratorType.entries) { type ->
+        withData(GeneratorType.Java, GeneratorType.Kotlin) { type ->
             shouldNotThrow<ClassNotFoundException> { Class.forName(type.fullyQualifiedName) }
         }
+    }
+    test("should equal self") {
+        GeneratorType.Kotlin shouldBeEqual GeneratorType.Kotlin
+        GeneratorType.Kotlin.hashCode() shouldBeEqual GeneratorType.Kotlin.hashCode()
+    }
+    test("should not equal other") {
+        GeneratorType.Kotlin shouldNotBeEqual GeneratorType.Java
     }
 })


### PR DESCRIPTION
Here is a suggestion of how to make the `GeneratorType` non-exhaustive.

I'm not totally satisfied... But at least it's not exhaustive.