### PR TITLE
fix: Default generated packge to `org.jooq.generated` if the project `group` is not defined

### DIFF
--- a/examples/default_config/build.gradle.kts
+++ b/examples/default_config/build.gradle.kts
@@ -3,9 +3,6 @@ plugins {
     id("com.optravis.jooq")
 }
 
-// IMPORTANT: The group determines the package of generated jooq files
-group = "com.optravis.jooq.gradle.example"
-
 repositories {
     mavenCentral()
 }

--- a/examples/default_config/src/test/kotlin/com/optravis/jooq/gradle/ExampleTest.kt
+++ b/examples/default_config/src/test/kotlin/com/optravis/jooq/gradle/ExampleTest.kt
@@ -1,11 +1,11 @@
 package com.optravis.jooq.gradle
 
-import com.optravis.jooq.gradle.example.jooq.tables.references.BOOK
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import org.jooq.SQLDialect
 import org.jooq.impl.DSL
+import org.jooq.generated.tables.references.BOOK
 
 class ExampleTest : FunSpec({
     isolationMode = IsolationMode.InstancePerLeaf

--- a/examples/with_config/build.gradle.kts
+++ b/examples/with_config/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     id("com.optravis.jooq")
 }
 
-// IMPORTANT: The group determines the package of generated jooq files
 group = "com.optravis.jooq.gradle.example"
 
 repositories {

--- a/src/main/kotlin/com/optravis/jooq/gradle/JooqGeneratorPlugin.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/JooqGeneratorPlugin.kt
@@ -46,7 +46,12 @@ public class JooqGeneratorPlugin : Plugin<Project> {
             jooqDbConfig.convention(ext.jooqDbConfig)
             migrationDirectory.convention(ext.migrationDirectory)
             generatorConfig.convention(ext.generatorConfig)
-            packageName.convention(ext.packageName.orElse("${project.group}.jooq"))
+            packageName.convention(ext.packageName.orElse(
+                project.group.toString()
+                    .takeUnless { it.isBlank() }
+                    ?.let { "$it.jooq" }
+                    ?: "org.jooq.generated"
+            ))
         }
         "compileJava" { dependsOn(generateTask) }
         "compileKotlin" { dependsOn(generateTask) }


### PR DESCRIPTION
fix #26
