### PR TITLE
feat(configuration): allow to configure the generated visibility modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ import com.optravis.jooq.gradle.ExperimentalJooqGeneratorConfig
 import com.optravis.jooq.gradle.GeneratorType
 import com.optravis.jooq.gradle.JooqDatabaseConfig
 import com.optravis.jooq.gradle.JooqGeneratorConfig
+import org.jooq.meta.jaxb.VisibilityModifier
 
 @OptIn(ExperimentalJooqGeneratorConfig::class)
 jooqGenerator {
@@ -73,6 +74,7 @@ jooqGenerator {
             daos = true,
             pojos = true,
             javaTimeTypes = true,
+            visibilityModifier = VisibilityModifier.DEFAULT,
         )
     )
 }

--- a/examples/with_config/build.gradle.kts
+++ b/examples/with_config/build.gradle.kts
@@ -3,6 +3,7 @@ import com.optravis.jooq.gradle.ExperimentalJooqGeneratorConfig
 import com.optravis.jooq.gradle.GeneratorType
 import com.optravis.jooq.gradle.JooqDatabaseConfig
 import com.optravis.jooq.gradle.JooqGeneratorConfig
+import org.jooq.meta.jaxb.VisibilityModifier
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -41,6 +42,7 @@ jooqGenerator {
             daos = true,
             pojos = true,
             javaTimeTypes = true,
+            visibilityModifier = VisibilityModifier.DEFAULT,
         )
     )
 }

--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -1,8 +1,8 @@
 package com.optravis.jooq.gradle
 
+import org.jooq.meta.jaxb.VisibilityModifier
 import java.io.File
 import java.io.Serializable
-
 
 @RequiresOptIn(
     message = "This configuration API is not yet stabilized and is subject to breaking changes",
@@ -35,6 +35,7 @@ public data class JooqGeneratorConfig(
     internal val kotlinPojos: Boolean = true,
     internal val pojos: Boolean = kotlinPojos,
     internal val daos: Boolean = true,
+    internal val visibilityModifier: VisibilityModifier = VisibilityModifier.DEFAULT
 ) : Serializable
 
 /** Generator type currently supported by this plugin. */

--- a/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
@@ -71,6 +71,7 @@ private fun JooqRootConfig.toConfiguration(jdbcUrl: String) =
 
 private fun JooqGeneratorConfig.toJooqGenerate(): Generate {
     val common = Generate()
+        .withVisibilityModifier(visibilityModifier)
         .withDaos(daos)
         .withPojos(pojos)
         .withJavaTimeTypes(javaTimeTypes)


### PR DESCRIPTION
This adds the ability to configure which visibility modifier the generated code should have.

See: https://www.jooq.org/doc/3.15/manual/code-generation/codegen-advanced/codegen-config-generate/codegen-generate-visibility-modifier/

@ursjoss, I'm not sure about adding `org.jooq.meta.jaxb.VisibilityModifier` into the public API. It is convenient because it already exists, but I wonder if I should hide it behind our own enum. What do you think?