### PR TITLE
fix(deps): remove dependency on hikariCP

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,11 +19,10 @@ dependencies {
     implementation(libs.jooq.codegen)
     implementation(libs.flyway.core)
     implementation(libs.testcontainers.core)
-    implementation(libs.hikari)
+    implementation(libs.postgresql)
 
     runtimeOnly(libs.jooq.meta.kotlin)
     runtimeOnly(libs.flyway.postgres)
-    runtimeOnly(libs.postgresql)
 
     testImplementation(rootProject.libs.kotest.runner)
     testImplementation(rootProject.libs.kotest.assertions)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ flyway = "10.21.0"
 jooq = "3.19.15"
 testcontainers = "1.20.3"
 postgres = "42.7.4"
-hikari = "6.2.0"
 gradle-plugin-publish = "1.3.0"
 
 [plugins]
@@ -34,7 +33,6 @@ testcontainers-postgresql = { module = "org.testcontainers:postgresql", version.
 
 # DB access
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgres" }
-hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
 
 # Test
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }

--- a/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Generator.kt
@@ -2,8 +2,6 @@
 
 package com.optravis.jooq.gradle
 
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
 import org.flywaydb.core.Flyway
 import org.jooq.codegen.GenerationTool
 import org.jooq.meta.jaxb.Configuration
@@ -12,6 +10,7 @@ import org.jooq.meta.jaxb.Generate
 import org.jooq.meta.jaxb.Generator
 import org.jooq.meta.jaxb.Jdbc
 import org.jooq.meta.jaxb.Target
+import org.postgresql.ds.PGSimpleDataSource
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
@@ -36,11 +35,14 @@ internal fun JooqRootConfig.generate() {
 }
 
 private fun DbConnectionConfig.isReady(jdbcUrl: String): Boolean {
-    val config = HikariConfig()
-    config.jdbcUrl = jdbcUrl
-    config.username = user
-    config.password = password
-    return runCatching { HikariDataSource(config).connection.close() }.isSuccess
+    return runCatching {
+        PGSimpleDataSource().apply {
+            setUrl(jdbcUrl)
+            user = this@isReady.user
+            password = this@isReady.password
+            connection.close()
+        }
+    }.isSuccess
 }
 
 private fun JooqRootConfig.toConfiguration(jdbcUrl: String) =


### PR DESCRIPTION
The purpose of Hikari is to manage a connection pool. But as we only need a single (and ephemeral) connection to the database, I suggest we remove that dependency.