### PR TITLE
fix(deps)!: Upgrade to Java 21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: 17
+          java-version: 21
           cache: gradle
 
       - uses: taiki-e/install-action@v2
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: 17
+          java-version: 21
           cache: gradle
 
       - uses: taiki-e/install-action@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,13 +46,13 @@ gradlePlugin {
 java {
     withSourcesJar()
     withJavadocJar()
-    sourceCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
 }
 
 kotlin {
     explicitApi()
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget.set(JvmTarget.JVM_21)
     }
 }
 


### PR DESCRIPTION
I think it should be acceptable to upgrade to Java 21 for few reasons.

* Java 21 is LTS and was released 17 months ago
* jOOQ 3.20.0 is compiled with Java 21 (see: https://github.com/jOOQ/jOOQ/releases/tag/version-3.20.0 and https://github.com/jOOQ/jOOQ/issues/15177)
