### PR TITLE
feat: add a way to change the base image underneath

### DIFF
--- a/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
+++ b/src/main/kotlin/com/optravis/jooq/gradle/Config.kt
@@ -67,8 +67,9 @@ public data class ContainerConfig(
             password: String = Default.PASSWORD,
             version: String = "16",
             port: Int = 5432,
+            baseImage: String = "postgres:"
         ): ContainerConfig = ContainerConfig(
-            image = "postgres:$version",
+            image = "$baseImage$version",
             port = port,
             environment = mapOf(
                 "POSTGRES_DB" to db,


### PR DESCRIPTION
This makes it possible to change up the base image of postgres.

### Why:

Extensions like [pgvector](https://github.com/pgvector/pgvector/blob/master/README.md#docker) are to be added extra via their own image or via an custom pg image

### Alternatives without breaking changes

adding another postgres function with different parameters:

```kotlin
        public fun postgres_image(
            db: String = Default.DB,
            user: String = Default.USER,
            password: String = Default.PASSWORD,
            image: String = "postgres:16",
            port: Int = 5432
        ): ContainerConfig = ContainerConfig(...)
 
```

an extension function that overwrites the image property and returns itself

```kotlin
        fun ContainerConfig.image(image: String): ContainerConfig(...)
 
```

making the image property public so one can use the copy function?

## Notes

Using 'postgres:' is not by accident as it allows the most freedom to change the image.

Adding the baseimage string makes it non breaking but it also limits the naming of the images one can use, the version always needs to be at then or we would force the user to add an empty string as the version and include it into the baseImage string.


